### PR TITLE
Refactoring and few fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ shopier.setOrderShipping({
 #### For 15₺:
 
 ```javascript
-const paymentPage = shopier.payment(15);
+const paymentPage = shopier.generatePaymentHTML(15);
 ```
 
 > This will return the purchase form as html.

--- a/src/enums/currencyTypes.enum.ts
+++ b/src/enums/currencyTypes.enum.ts
@@ -1,0 +1,5 @@
+export enum CurrencyType {
+  TL,
+  USD,
+  EUR
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,9 +131,10 @@ export class Shopier {
     return current_lan;
   }
 
-  callback(body: any, apiSecret: string): ICallback | boolean {
-    const data = body.random_nr + body.platform_order_id;
-    const hmac = createHmac('sha256', apiSecret);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  callback(body: any): ICallback | false {
+    const data = `${body.random_nr}${body.platform_order_id}`;
+    const hmac = createHmac('sha256', this.apiSecret);
     hmac.update(data);
     const expected = hmac.digest('base64');
     if (body.signature === expected) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   ICallback
 } from './interfaces';
 import { PlatformType, ProductType } from './enums';
+import { CurrencyType } from './enums/currencyTypes.enum';
 
 export class Shopier {
   private paymentUrl: string =
@@ -16,7 +17,7 @@ export class Shopier {
   private buyer: IBuyer = {} as IBuyer;
   private orderBilling: IBillingAddress = {} as IBillingAddress;
   private orderShipping: IShippingAddress = {} as IShippingAddress;
-  private currency: string = 'TRY';
+  private currency: CurrencyType = CurrencyType.TL;
   private moduleVersion: string = '1.0.4';
 
   constructor(apiKey: string, apiSecret: string) {
@@ -113,8 +114,11 @@ export class Shopier {
     </html>`;
   }
 
-  setCurrency(currency: string) {
-    this.currency = currency;
+  setCurrency(currency: keyof typeof CurrencyType): this;
+  setCurrency(currency: CurrencyType): this;
+  setCurrency(currency: CurrencyType | keyof typeof CurrencyType) {
+    this.currency =
+      typeof currency === 'number' ? currency : CurrencyType[currency];
     return this;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,3 +151,5 @@ export class Shopier {
     }
   }
 }
+
+export * from './enums';

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import {
   ICallback
 } from './interfaces';
 import { PlatformType, ProductType } from './enums';
+import { deprecate } from 'util';
 import { CurrencyType } from './enums/currencyTypes.enum';
 
 export class Shopier {
@@ -92,7 +93,18 @@ export class Shopier {
       .join('');
   }
 
+  /**
+   * @deprecated Use `generatePaymentHTML(amount: number)` instead
+   */
   payment(amount: number): string {
+    deprecate(
+      this.payment,
+      'payment(amount: number) is deprecated. Use generatePaymentHTML(amount: number) instead.'
+    );
+    return this.generatePaymentHTML(amount);
+  }
+
+  generatePaymentHTML(amount: number): string {
     const obj = this.generateIForm(amount);
     return `<!doctype html>
     <html lang="en">

--- a/src/interfaces/form.interface.ts
+++ b/src/interfaces/form.interface.ts
@@ -4,7 +4,7 @@ export interface IForm extends IBuyer, IShippingAddress, IBillingAddress {
   API_key: string;
   website_index: number;
   total_order_value: number;
-  currency: string;
+  currency: number;
   platform: number;
   is_in_frame: number;
   current_language: number;


### PR DESCRIPTION
This PR introduces the following changes:
- Fix a bug caused by a curse of JavaScript libraries, which parses queries to numbers so `random_nr + platform_order_id` becomes an addition au lieu of concatenating
- change Shopier#payment to Shopier#generatePaymentHTML for better self-explaination
    - deprecate Shopier#payment in favor of Shopier#generatePaymentHTML 
- export enums as they are required to call some functions